### PR TITLE
 Added self._global_defines check under def _check_if_extra_flags(self):

### DIFF
--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -109,7 +109,7 @@ class XcodeToolchain(object):
 
     @property
     def _check_if_extra_flags(self):
-        return self._global_cflags or self._global_cxxflags or self._global_ldflags
+        return self._global_cflags or self._global_cxxflags or self._global_ldflags or self._global_defines
 
     @property
     def _flags_xcconfig_content(self):


### PR DESCRIPTION


Changelog: (Bugfix): 

Docs state that the global xcode config will be generated with modification of the above, including exelinkflags and defines, but the _check_if_extra_flags(self) only checks for cflags/cxxflags/ldflags/exelinkflags.

Docs: https://docs.conan.io/2/reference/tools/apple/xcodetoolchain.html#xcodetoolchain-conf

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
